### PR TITLE
Update Global classes for marking by a template parameter.

### DIFF
--- a/luatic/empty.hpp
+++ b/luatic/empty.hpp
@@ -1,0 +1,18 @@
+/* =============================================================================
+ * Copyright (c) 2017 tacigar
+ * https://github.com/tacigar/Luatic
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See accompanying
+ * file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ * ============================================================================= */
+
+#ifndef __LUATIC_EMPTY_HPP__
+#define __LUATIC_EMPTY_HPP__
+
+namespace luatic {
+
+    struct Empty {};
+    
+} // namespace luatic
+
+#endif // __LUATIC_EMPTY_HPP__

--- a/luatic/namespace.hpp
+++ b/luatic/namespace.hpp
@@ -21,7 +21,7 @@ namespace luatic {
     
     namespace detail {
 
-        template <int N>
+        template <class Marker, int N>
         class Global_;
         
         template <class Outer, int N>
@@ -79,12 +79,12 @@ namespace luatic {
             Outer _outer;
         };
 
-        template <int M, int N>
-        class Namespace_<Global_<M>, N> {
+        template <class Marker, int M, int N>
+        class Namespace_<Global_<Marker, M>, N> {
             template <class O, int K>
             friend class luatic::detail::Namespace_;
         private:
-            using Outer = Global_<M>;
+            using Outer = Global_<Marker, M>;
             
         public:
             Namespace_(lua_State* L, const std::string& name,
@@ -105,7 +105,7 @@ namespace luatic {
 
             auto end() -> decltype(auto) {
                 lua_setglobal(_L, _name.data());
-                return Global_<M + 1>(_L);
+                return Global_<Marker, M + 1>(_L);
             }
 
             template <class F>

--- a/sample/01-Hello/main.cpp
+++ b/sample/01-Hello/main.cpp
@@ -14,7 +14,7 @@ auto main() -> int {
         return EXIT_FAILURE;
     }
 
-    luatic::Global(L)
+    luatic::Global<>(L)
         .begin()
             .defFunction("hello_from_the_other_side", hello_from_the_other_side)
             // use positive lambda, not normal lambda.

--- a/sample/02-Std/main.cpp
+++ b/sample/02-Std/main.cpp
@@ -12,7 +12,7 @@ auto main() -> int {
         return EXIT_FAILURE;
     }
 
-    luatic::Global(L)
+    luatic::Global<>(L)
         .begin()
             .defNamespace("std")
             .begin()


### PR DESCRIPTION
今のままでは絶対に一度に全ての登録をしなければならないため, Globalクラスにマーカーを付けられるようにした.